### PR TITLE
Disable TLS Override

### DIFF
--- a/lib/bronto/base.rb
+++ b/lib/bronto/base.rb
@@ -54,8 +54,6 @@ module Bronto
       @api = Savon::Client.new do
         wsdl.endpoint = "https://api.bronto.com/v4"
         wsdl.namespace = "http://api.bronto.com/v4"
-        http.auth.ssl.verify_mode = :none
-        http.auth.ssl.ssl_version = :TLSv1
       end
 
       # Give Bronto up to 10 minutes to reply


### PR DESCRIPTION
This override restricting SSL/TLS support to only TLS version 1 is no
longer appropriate. Bronto now properly supports modern SSL standards
and has stopped supporting TLSv1.

Removing this override lets us use an accepted version of TLS (v1.2)
and re-enables communication with Bronto's API.
